### PR TITLE
Insert soft hyphens within long non-dictionary word

### DIFF
--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -39,7 +39,7 @@
 			<p>“Hold hard a minute, then!” said the Rat. He looped the painter through a ring in his landing-stage, climbed up into his hole above, and after a short interval reappeared staggering under a fat wicker luncheon-basket.</p>
 			<p>“Shove that under your feet,” he observed to the Mole, as he passed it down into the boat. Then he untied the painter and took the sculls again.</p>
 			<p>“What’s inside it?” asked the Mole, wriggling with curiosity.</p>
-			<p>“There’s cold chicken inside it,” replied the Rat briefly: “coldtonguecoldhamcoldbeefpickledgherkinssaladfrenchrollscresssandwichespottedmeatgingerbeerlemonadesodawater⁠—”</p>
+			<p>“There’s cold chicken inside it,” replied the Rat briefly: “cold­tongue­cold­ham­cold­beef­pickled­gherkins­salad­french­rolls­cress­sandwiches­potted­meat­ginger­beer­lemonade­soda­water⁠—”</p>
 			<p>“O stop, stop!” cried the Mole in ecstasies. “This is too much!”</p>
 			<p>“Do you really think so?” enquired the Rat seriously. “It’s only what I always take on these little excursions; and the other animals are always telling me that I’m a mean beast and cut it <em>very</em> fine!”</p>
 			<p>The Mole never heard a word he was saying. Absorbed in the new life he was entering upon, intoxicated with the sparkle, the ripple, the scents and the sounds and the sunlight, he trailed a paw in the water and dreamed long waking dreams. The Water Rat, like the good little fellow he was, sculled steadily on and forbore to disturb him.</p>


### PR DESCRIPTION
This word sticks out (literally) and triggers a horizontal scrollbar in my browser.

![willows](https://user-images.githubusercontent.com/126009/110740649-a4af0600-81f0-11eb-9d26-2f4ade796f9f.png)

Much better with soft hyphens:

![willows2](https://user-images.githubusercontent.com/126009/110740767-d3c57780-81f0-11eb-8781-01123592fc89.png)

I only inserted between words within the word, rather than syllables; I think that makes more sense in this case.