### PR TITLE
Fix ellipses formatting

### DIFF
--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -79,7 +79,7 @@
 			<p>“Such a good fellow, too,” remarked the Otter reflectively; “but no stability⁠—especially in a boat!”</p>
 			<p>From where they sat they could get a glimpse of the main stream across the island that separated them; and just then a wager-boat flashed into view, the rower⁠—a short, stout figure⁠—splashing badly and rolling a good deal, but working his hardest. The Rat stood up and hailed him, but Toad⁠—for it was he⁠—shook his head and settled sternly to his work.</p>
 			<p>“He’ll be out of the boat in a minute if he rolls like that,” said the Rat, sitting down again.</p>
-			<p>“Of course he will,” chuckled the Otter. “Did I ever tell you that good story about Toad and the lock-keeper? It happened this way. Toad.⁠ ⁠…”</p>
+			<p>“Of course he will,” chuckled the Otter. “Did I ever tell you that good story about Toad and the lock-keeper? It happened this way. Toad⁠…”</p>
 			<p>An errant Mayfly swerved unsteadily athwart the current in the intoxicated fashion affected by young bloods of Mayflies seeing life. A swirl of water and a “cloop!” and the Mayfly was visible no more.</p>
 			<p>Neither was the Otter.</p>
 			<p>The Mole looked down. The voice was still in his ears, but the turf whereon he had sprawled was clearly vacant. Not an Otter to be seen, as far as the distant horizon.</p>


### PR DESCRIPTION
In the original text it's `Toad....`, which in the conversion got turned into a single period and a unicode ellipses. This changes it to a single unicode ellipses.